### PR TITLE
Fix Parameters (RUN_OPTS)

### DIFF
--- a/root/etc/services.d/satip/run
+++ b/root/etc/services.d/satip/run
@@ -2,5 +2,7 @@
 
 cd /app/satip || exit
 
+IFS=" " read -r -a RUN_ARRAY <<< "$RUN_OPTS"
+
 exec \
-	./minisatip "${RUN_OPTS}" -f -x 8875
+        ./minisatip "${RUN_ARRAY[@]}" -f -x 8875


### PR DESCRIPTION
Parameters specified in RUN_OPTS are not recognized by minisatip if using double dashes (e.g. --satip-xml).
This fix is inspired by tvheadend docker.
